### PR TITLE
add getFileStreamController method

### DIFF
--- a/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
@@ -42,6 +42,7 @@ abstract class BaseCacheManager {
       {String? key, Map<String, String>? headers, bool withProgress});
 
   /// Get the file from the cache and/or online, depending on availability and age.
+  
   /// Downloaded form [url], [headers] can be used for example for authentication.
   /// The files are returned as stream. First the cached file if available, when the
   /// cached file is too old the newly downloaded file is returned afterwards.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
added getFileStreamController method, trying to close the stream so that we can cancel the download,

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
